### PR TITLE
Change how the ping is fetched

### DIFF
--- a/src/main/java/de/razuuu/fabric/advancedhud/Utils.java
+++ b/src/main/java/de/razuuu/fabric/advancedhud/Utils.java
@@ -1,12 +1,30 @@
 package de.razuuu.fabric.advancedhud;
 
+import de.razuuu.fabric.advancedhud.config.AdvancedHudConfig;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.ClientPlayNetworkHandler;
 import net.minecraft.client.network.PlayerListEntry;
+import net.minecraft.util.profiler.MultiValueDebugSampleLogImpl;
 
 public class Utils {
 
     public static int getLocalPing() {
+        MinecraftClient mc = MinecraftClient.getInstance();
+
+        MultiValueDebugSampleLogImpl pingLog = mc.inGameHud.getDebugHud().getPingLog();
+
+        // 20 should give somewhat the average ping but should still update quickly for lag spikes
+        int sampleSize = Math.min(pingLog.getLength(), 20);
+        long totalPing = 0;
+        for (int i = 0; i < sampleSize; i++) {
+            totalPing += pingLog.get(i);
+        }
+        // if it's 0 something maybe went wrong
+        // don't want to divide by 0 that's dumb
+        if (totalPing > 0 && sampleSize > 1) {
+            return Math.round(totalPing / (float) sampleSize);
+        }
+
         ClientPlayNetworkHandler networkHandler = MinecraftClient.getInstance().getNetworkHandler();
         if (networkHandler == null) {
             return -1;
@@ -18,5 +36,10 @@ public class Utils {
         }
 
         return localPlayer.getLatency();
+    }
+
+    public static boolean shouldRenderHud(MinecraftClient client) {
+        AdvancedHudConfig config = AdvancedHudMod.CONFIG;
+        return !client.options.hudHidden && config.enabled && config.textAlpha > 3 && AdvancedHudMod.SHOW_HUD_OVERLAY && client.player != null;
     }
 }

--- a/src/main/java/de/razuuu/fabric/advancedhud/mixin/ClientPlayNetworkHandlerMixin.java
+++ b/src/main/java/de/razuuu/fabric/advancedhud/mixin/ClientPlayNetworkHandlerMixin.java
@@ -1,0 +1,19 @@
+package de.razuuu.fabric.advancedhud.mixin;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import de.razuuu.fabric.advancedhud.Utils;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.hud.DebugHud;
+import net.minecraft.client.network.ClientPlayNetworkHandler;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(ClientPlayNetworkHandler.class)
+public class ClientPlayNetworkHandlerMixin {
+	// It doesn't send the packet if F3 is closed
+	@WrapOperation(method = "tick", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/hud/DebugHud;shouldShowPacketSizeAndPingCharts()Z"))
+	private boolean shouldShowPacketSizeAndPingCharts(DebugHud instance, Operation<Boolean> original) {
+		return Utils.shouldRenderHud(MinecraftClient.getInstance()) || original.call(instance);
+	}
+}

--- a/src/main/java/de/razuuu/fabric/advancedhud/mixin/InGameHudMixin.java
+++ b/src/main/java/de/razuuu/fabric/advancedhud/mixin/InGameHudMixin.java
@@ -22,11 +22,11 @@ import java.util.List;
 public class InGameHudMixin {
 
     @Inject(at = @At("TAIL"), method = "render")
-    public void render(DrawContext context, RenderTickCounter tickCounter, CallbackInfo ci) throws Exception {
+    public void render(DrawContext context, RenderTickCounter tickCounter, CallbackInfo ci) {
         MinecraftClient client = MinecraftClient.getInstance();
         AdvancedHudConfig config = AdvancedHudMod.CONFIG;
 
-        if (!client.options.hudHidden && config.enabled && config.textAlpha > 3 && AdvancedHudMod.SHOW_HUD_OVERLAY && client.player != null) {
+        if (Utils.shouldRenderHud(client)) {
             double guiScale = client.getWindow().getScaleFactor();
 
             List<String> textLines = getStrings(config, client);

--- a/src/main/resources/advancedhud.mixins.json
+++ b/src/main/resources/advancedhud.mixins.json
@@ -1,14 +1,15 @@
 {
-    "required": true,
-    "minVersion": "0.8",
-    "package": "de.razuuu.fabric.advancedhud.mixin",
-    "compatibilityLevel": "JAVA_21",
-    "mixins": [],
-    "client": [
-        "InGameHudMixin",
-        "MinecraftClientMixin"
-    ],
-    "injectors": {
-        "defaultRequire": 1
-    }
+  "required": true,
+  "minVersion": "0.8",
+  "package": "de.razuuu.fabric.advancedhud.mixin",
+  "compatibilityLevel": "JAVA_21",
+  "mixins": [],
+  "client": [
+    "ClientPlayNetworkHandlerMixin",
+    "InGameHudMixin",
+    "MinecraftClientMixin"
+  ],
+  "injectors": {
+    "defaultRequire": 1
+  }
 }


### PR DESCRIPTION
Added fetching the ping directly from the ping packet in priority. This fixes the fact that sometimes servers don't send the player's in the player list *cough cough* hypixel *cough cough*.

Touched a few things as well
- made a `shouldRenderHud` util cuz i needed the condition in 2 places.
- removed the throws exception cuz why was it there?

Pretty sure the ping packet was in 1.20.2 or something like that. So it can be backported over there if wanted.